### PR TITLE
correct Template DB `display_name` and `description`

### DIFF
--- a/products/template_db/template_db/metadata.yml
+++ b/products/template_db/template_db/metadata.yml
@@ -1,8 +1,9 @@
 name: dcp_template_db
-display_name: "Template DB (Overridden at the dest level)"
+display_name: Template DB
 summary: |
   Template DB is a mock dataset created by the Data Engineering team at the Department of City Planning (DCP).
-description: "Overriding at the the destination-level"
+description: |
+  Template DB is a mock dataset created by the Data Engineering team at the Department of City Planning (DCP).
 tags: [Department of City Planning, DCP, New York City, NYC]
 each_row_is_a: Interesting place in NYC
 


### PR DESCRIPTION
otherwise, the `data_dictionary.pdf` looks like this:

![Screenshot 2024-08-15 at 11 59 24 AM](https://github.com/user-attachments/assets/7426389f-1a69-4f33-9055-adf6ae1fcbdc)
