### PR TITLE
GIS Team Review of metadata

### DIFF
--- a/products/lion/2010_census_blocks/metadata.yml
+++ b/products/lion/2010_census_blocks/metadata.yml
@@ -10,6 +10,7 @@ attributes:
   - gis
   - map
   - dcp
+  date_made_public: '1/31/2013'
 
 assembly: []
 
@@ -64,9 +65,9 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        2010 Census Blocks from the US Census for New York City. These boundary files are derived from the US Census Bureau's TIGER data products and have been geographically modified to fit the New York City base map.
+        2010 Census Blocks from the US Census for New York City. These boundary files are derived from the US Census Bureau's TIGER data products and have been geographically modified to fit the New York City basemap.
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive.</a>
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive.</a>
       display_name: 2010 Census Blocks
 - file:
     id: shapefile_water_included
@@ -75,7 +76,7 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        2010 Census Blocks (water areas included) from the US Census for New York City. These boundary files are derived from the US Census Bureau's TIGER data products and have been geographically modified to fit the New York City base map.
+        2010 Census Blocks (water areas included) from the US Census for New York City. These boundary files are derived from the US Census Bureau's TIGER data products and have been geographically modified to fit the New York City basemap.
 
         All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive.</a>
       display_name: 2010 Census Blocks (water areas included)
@@ -115,7 +116,7 @@ columns:
 - id: boroname
   name: BoroName
   data_type: text
-  description: Borough Name.
+  description: Borough name.
   example: Queens
   values:
   - value: Brooklyn
@@ -131,8 +132,8 @@ columns:
 - id: bctcb2010
   name: BCTCB2010
   data_type: text
-  description: Merged string value of the BoroCode, census tract number, and census
-    block number.
+  description: Merged string value of the borough code (BoroCode), census tract number (CT2010), and census
+    block number (CB2010).
   example: '20060002009'
 - id: shape_area
   name: Shape__Area
@@ -147,4 +148,5 @@ columns:
 - id: the_geom
   name: the_geom
   data_type: geometry
+  description: None
   example: None

--- a/products/lion/2010_census_blocks/metadata.yml
+++ b/products/lion/2010_census_blocks/metadata.yml
@@ -78,7 +78,7 @@ files:
       description: |-
         2010 Census Blocks (water areas included) from the US Census for New York City. These boundary files are derived from the US Census Bureau's TIGER data products and have been geographically modified to fit the New York City basemap.
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive.</a>
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive.</a>
       display_name: 2010 Census Blocks (water areas included)
 - file:
     id: nycb2010_metadata.pdf

--- a/products/lion/2010_census_tracts/metadata.yml
+++ b/products/lion/2010_census_tracts/metadata.yml
@@ -13,6 +13,7 @@ attributes:
   - census
   - water areas
   - gis
+  date_made_public: '1/31/2013'
 
 assembly: []
 
@@ -67,9 +68,9 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        2010 Census Tracts from the US Census for New York City. These boundary files are derived from the US Census Bureau's TIGER data products and have been geographically modified to fit the New York City base map.
+        2010 Census Tracts from the US Census for New York City. These boundary files are derived from the US Census Bureau's TIGER data products and have been geographically modified to fit the New York City basemap.
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
       display_name: 2010 Census Tracts
 - file:
     id: shapefile_water_included
@@ -78,9 +79,9 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        2010 Census Tracts (water areas included) from the US Census for New York City. These boundary files are derived from the US Census Bureau's TIGER data products and have been geographically modified to fit the New York City base map.
+        2010 Census Tracts (water areas included) from the US Census for New York City. These boundary files are derived from the US Census Bureau's TIGER data products and have been geographically modified to fit the New York City basemap.
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
       display_name: 2010 Census Tracts (water areas included)
 - file:
     id: nyct2010_metadata.pdf
@@ -104,7 +105,7 @@ columns:
 - id: ctlabel
   name: CTLabel
   data_type: text
-  description: The census tract identifier for the polygon. Each 2010 census tract
+  description: The census tract identifier for maps and publication. Uses the least number of digits. Each 2010 census tract
     number is unique to its borough.
   example: None
 - id: borocode

--- a/products/lion/2010_census_tracts/metadata.yml
+++ b/products/lion/2010_census_tracts/metadata.yml
@@ -2,8 +2,8 @@ id: 2010_census_tracts
 
 attributes:
   description: |-
-    2010 Census Tracts from the US Census for New York City. These boundary files are derived from the US Census Bureau's TIGER data products and have been geographically modified to fit the New York City base map.
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    2010 Census Tracts from the US Census for New York City. These boundary files are derived from the US Census Bureau's TIGER data products and have been geographically modified to fit the New York City basemap.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: 2010 Census Tracts
   each_row_is_a: Census Tract
   tags:
@@ -12,6 +12,7 @@ attributes:
   - city planning
   - census
   - water areas
+  - gis
 
 assembly: []
 
@@ -96,6 +97,7 @@ columns:
 - id: the_geom
   name: the_geom
   data_type: geometry
+  description: None
   example: None
   custom:
     readme_data_type: geometry
@@ -124,7 +126,7 @@ columns:
 - id: boroname
   name: BoroName
   data_type: text
-  description: Borough Name.
+  description: Borough name.
   example: Queens
   values:
   - value: Brooklyn
@@ -135,32 +137,32 @@ columns:
 - id: ct2010
   name: CT2010
   data_type: text
-  description: String value of the 2010 census tract number.
+  description: Census tract number.
   example: None
 - id: boroct2010
   name: BoroCT2010
   data_type: text
-  description: Merged string of borough code and 2010 census tract number.
+  description: Merged string of borough code (BoroCode) and census tract number (CT2010).
   example: '20060002009'
 - id: cdeligibil
   name: CDEligibil
   data_type: text
-  description: Community Development Block Grant Eligibility.
+  description: Community Development Block Grant eligibility.
   example: None
 - id: ntacode
   name: NTACode
   data_type: text
-  description: 2010 Neighborhood Tabulation Area Code
+  description: 2010 Neighborhood Tabulation Area code.
   example: None
 - id: ntaname
   name: NTAName
   data_type: text
-  description: 2010 Neighborhood Tabulation Area Name
+  description: 2010 Neighborhood Tabulation Area name.
   example: None
 - id: puma
   name: PUMA
   data_type: text
-  description: 2010 Public Use Microdata Area code
+  description: 2010 Public Use Microdata Area code.
   example: None
 - id: shape_area
   name: Shape__Area

--- a/products/lion/2010_neighborhood_tabulation_areas/metadata.yml
+++ b/products/lion/2010_neighborhood_tabulation_areas/metadata.yml
@@ -5,7 +5,7 @@ attributes:
     2010 Neighborhood Tabulation Areas (NTAs) are medium-sized statistical geographies for reporting Decennial Census and American Community Survey (ACS). 2010 NTAs are created by aggregating 2020 census tracts and nest within Community District Tabulation Areas (CDTA). NTAs were delineated with the need for both geographic specificity and statistical reliability in mind. Consequently, each NTA contains enough population to mitigate sampling error associated with the ACS yet offers a unit of analysis that is smaller than a Community District.
     Though NTA boundaries and their associated names roughly correspond with many neighborhoods commonly recognized by New Yorkers, NTAs are not intended to definitively represent neighborhoods, nor are they intended to be exhaustive of all possible names and understandings of neighborhoods throughout New York City. Additionally, non-residential areas including large parks, airports, cemeteries, and other special areas are represented separately within this dataset and are assigned codes according to their type (See NTAType field).
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>
   display_name: 2010 Neighborhood Tabulation Areas (NTAs)
   each_row_is_a: Neighborhood Tabulation Area
   tags:
@@ -15,6 +15,7 @@ attributes:
   - community
   - area
   - nta
+  date_made_public: '1/31/2013'
 
 assembly: []
 
@@ -74,7 +75,7 @@ columns:
 - id: boroname
   name: BoroName
   data_type: text
-  description: Borough Name.
+  description: Borough name.
   example: None
   values:
   - value: Brooklyn
@@ -85,12 +86,12 @@ columns:
 - id: countyfips
   name: CountyFIPS
   data_type: text
-  description: The Census Bureau defined County FIPS code
+  description: The Census Bureau defined county FIPS code.
   example: None
 - id: ntacode
   name: NTACode
   data_type: text
-  description: 2010 Neighborhood Tabulation Area Code
+  description: 2010 Neighborhood Tabulation Area code.
   example: None
 - id: ntaname
   name: NTAName

--- a/products/lion/2010_public_use_microdata_areas/metadata.yml
+++ b/products/lion/2010_public_use_microdata_areas/metadata.yml
@@ -8,13 +8,13 @@ attributes:
   display_name: 2010 Public Use Microdata Areas (PUMAs)
   each_row_is_a: Public Use Microdata Area
   tags:
-    - public use microdata area
-    - dcp
-    - city planning
-    - community
-    - area
-    - puma
-    - census
+  - public use microdata area
+  - dcp
+  - city planning
+  - community
+  - area
+  - puma
+  - census
   date_made_public: '7/14/2015'
 
 assembly: []

--- a/products/lion/2010_public_use_microdata_areas/metadata.yml
+++ b/products/lion/2010_public_use_microdata_areas/metadata.yml
@@ -2,12 +2,20 @@ id: 2010_public_use_microdata_areas
 
 attributes:
   description: |-
-    The 2010 NYC Public Use Microdata Areas (PUMAs) are statistical geographic areas defined for the dissemination of Public Use Microdata Sample (PUMS) data. PUMAs have a minimum population of 100,000 and were aggregated from 2010 census tracts. These boundary files are derived from the US Census Bureau's TIGER project and have been geographically modified to fit the New York City base map.
+    The 2010 NYC Public Use Microdata Areas (PUMAs) are statistical geographic areas defined for the dissemination of Public Use Microdata Sample (PUMS) data. PUMAs have a minimum population of 100,000 and were aggregated from 2010 census tracts. These boundary files are derived from the US Census Bureau's TIGER project and have been geographically modified to fit the New York City basemap.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>
   display_name: 2010 Public Use Microdata Areas (PUMAs)
   each_row_is_a: Public Use Microdata Area
-  tags: []
+  tags:
+    - public use microdata area
+    - dcp
+    - city planning
+    - community
+    - area
+    - puma
+    - census
+  date_made_public: '7/14/2015'
 
 assembly: []
 

--- a/products/lion/atomic_polygons/metadata.yml
+++ b/products/lion/atomic_polygons/metadata.yml
@@ -19,7 +19,7 @@ destinations:
 - id: socrata
   type: socrata
   files:
-  - id: []
+  - id: nyap_metadata.pdf
     custom:
       destination_use: attachment
   files:

--- a/products/lion/atomic_polygons/metadata.yml
+++ b/products/lion/atomic_polygons/metadata.yml
@@ -2,13 +2,14 @@ id: atomic_polygons
 
 attributes:
   description: |-
-    Atomic polygons serve as a set of basic building blocks for generating the polygons of many of the district types represented in the CSCL database. Feature classes such as election district, school district, census block, FDNY administrative company, and community district can be dissolved by combining the appropriate fields in atomic polygons.
+    Atomic polygons serve as a set of basic building blocks for generating the polygons of many of the district types represented in the NYC Street Centerline (CSCL) database. Feature classes such as election district, school district, census block, FDNY administrative company, and community district can be dissolved by combining the appropriate fields in atomic polygons.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Atomic Polygons
   each_row_is_a: Atomic Polygon
   tags:
   - atomic polygons
+  date_made_public: '3/6/2015'
 
 assembly: []
 
@@ -17,6 +18,10 @@ custom: {}
 destinations:
 - id: socrata
   type: socrata
+  files:
+  - id: []
+    custom:
+      destination_use: attachment
   files:
   - id: shapefile
     custom:
@@ -79,7 +84,7 @@ columns:
 - id: borough
   name: BOROUGH
   data_type: text
-  description: Borough Code
+  description: Borough Code.
   example: '4'
   values:
   - value: '1'
@@ -135,78 +140,78 @@ columns:
 - id: water_flag
   name: WATER_FLAG
   data_type: text
-  description: Flag to indicate the relationship of the Atomic Polygon to water
+  description: Flag to indicate the relationship of the atomic polygon to water.
   example: None
   values:
   - value: Water
-    description: Atomic polygon is under water that is part of the shoreline
+    description: Atomic polygon is under water that is part of the shoreline.
   - value: Non-Water
-    description: Atomic polygon is on land
+    description: Atomic polygon is on land.
   - value: Internal Water
     description: Atomic polygon is under water that is not part of the shoreline (lake,
       pond, reservior, etc.)
   - value: Pier
-    description: Atomic polygon is on a pier or structure over water
+    description: Atomic polygon is on a pier or structure over water.
 - id: assemdist
   name: ASSEMDIST
   data_type: text
-  description: State Assembly District Number
+  description: State Assembly district number.
   example: None
 - id: electdist
   name: ELECTDIST
   data_type: text
-  description: Three digit election district number
+  description: Three digit election district number.
   example: None
 - id: schooldist
   name: SCHOOLDIST
   data_type: text
-  description: The two digit school district number
+  description: The two digit school district number.
   example: None
 - id: commdist
   name: COMMDIST
   data_type: text
-  description: Community district number preceded by BoroCode
+  description: Community district number preceded by BoroCode.
   example: None
 - id: sb1_volume
   name: SB1_VOLUME
   data_type: text
-  description: First Sanborn volume the atomic polygon appears in
+  description: First Sanborn volume the atomic polygon appears in.
   example: None
 - id: sb1_page
   name: SB1_PAGE
   data_type: text
-  description: First Sanborn page the atomic polygon appears in
+  description: First Sanborn page the atomic polygon appears in.
   example: None
 - id: sb2_volume
   name: SB2_VOLUME
   data_type: text
-  description: Second Sanborn volume the atomic polygon appears in
+  description: Second Sanborn volume the atomic polygon appears in.
   example: None
 - id: sb2_page
   name: SB2_PAGE
   data_type: text
-  description: Second Sanborn page the atomic polygon appears in
+  description: Second Sanborn page the atomic polygon appears in.
   example: None
 - id: sb3_volume
   name: SB3_VOLUME
   data_type: text
-  description: Third Sanborn volume the atomic polygon appears in
+  description: Third Sanborn volume the atomic polygon appears in.
   example: None
 - id: sb3_page
   name: SB3_PAGE
   data_type: text
-  description: Third Sanborn page the atomic polygon appears in
+  description: Third Sanborn page the atomic polygon appears in.
   example: None
 - id: atomicid
   name: ATOMICID
   data_type: text
-  description: Unique ID for the atomic polygon
+  description: Unique ID for the atomic polygon.
   example: None
 - id: atomic_num
   name: ATOMIC_NUM
   data_type: text
-  description: Atomic Number is the 3 last digits of the Atomic ID. This field has
-    been depracated and is no longer maintained (all NULL values)
+  description: Atomic number is the 3 last digits of the Atomic ID. This field has
+    been deprecated and is no longer maintained (all NULL values).
   example: None
 - id: hurricane_evacuation_zone
   name: HURRICANE_EVACUATION_ZONE
@@ -235,17 +240,18 @@ columns:
 - id: commercial_waste_zone
   name: Commercial Waste Zone
   data_type: text
-  description: As part of the Department of Sanitation's (DSNY) comprehensive plan
-    for reforming the private carting industry, it has established Commercial Waste
-    Zones
+  description: Commercial Waste Zones established as part of the Department of Sanitation's (DSNY) comprehensive plan
+    for reforming the private carting industry.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: the_geom
   name: The_Geom

--- a/products/lion/borough_boundaries/metadata.yml
+++ b/products/lion/borough_boundaries/metadata.yml
@@ -2,7 +2,7 @@ id: borough_boundaries
 
 attributes:
   display_name: Borough Boundaries
-  each_row_is_a: Borough Boundary
+  each_row_is_a: Borough boundary
   tags:
   - borough boundaries
   - data

--- a/products/lion/borough_boundaries/metadata.yml
+++ b/products/lion/borough_boundaries/metadata.yml
@@ -8,6 +8,7 @@ attributes:
   - data
   - water areas
   - dcp
+  date_made_public: '1/31/2013'
 
 assembly: []
 
@@ -64,7 +65,7 @@ files:
       description: |-
         Boundaries of Boroughs (water areas included).
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
       display_name: Borough Boundaries (water areas included)
     overridden_columns:
     - id: shape_length
@@ -78,8 +79,8 @@ files:
       description: |-
         Boundaries of Boroughs (water areas excluded).
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
-      display_name: Borough Boundaries (water areas excluded)
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
+      display_name: Borough Boundaries
     overridden_columns:
     - id: shape_length
       name: shape_leng
@@ -98,7 +99,7 @@ columns:
 - id: borocode
   name: BoroCode
   data_type: integer
-  description: Borough Code
+  description: Borough Code.
   example: None
   values:
   - value: '1'

--- a/products/lion/borough_boundaries/metadata.yml
+++ b/products/lion/borough_boundaries/metadata.yml
@@ -63,7 +63,7 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        Boundaries of Boroughs (water areas included).
+        Boundaries of boroughs (water areas included).
 
         All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
       display_name: Borough Boundaries (water areas included)
@@ -77,7 +77,7 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        Boundaries of Boroughs (water areas excluded).
+        Boundaries of boroughs (water areas excluded).
 
         All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
       display_name: Borough Boundaries
@@ -99,7 +99,7 @@ columns:
 - id: borocode
   name: BoroCode
   data_type: integer
-  description: Borough Code.
+  description: Borough code.
   example: None
   values:
   - value: '1'
@@ -115,7 +115,7 @@ columns:
 - id: boroname
   name: BoroName
   data_type: text
-  description: Name of Borough.
+  description: Name of borough.
   example: None
   values:
   - value: Brooklyn

--- a/products/lion/city_council_districts/metadata.yml
+++ b/products/lion/city_council_districts/metadata.yml
@@ -20,6 +20,7 @@ attributes:
   - election
   - city council districts
   - dcp
+  date_made_public: []
 
 assembly: []
 

--- a/products/lion/community_districts/metadata.yml
+++ b/products/lion/community_districts/metadata.yml
@@ -19,6 +19,7 @@ attributes:
   - community
   - boundaries
   - water
+  date_made_public: []
 
 assembly: []
 

--- a/products/lion/congressional_districts/metadata.yml
+++ b/products/lion/congressional_districts/metadata.yml
@@ -2,7 +2,7 @@ id: congressional_districts
 
 attributes:
   description: |-
-    Boundaries of Congressional Districts.
+    Boundaries of congressional districts.
 
     All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Congressional Districts
@@ -76,7 +76,7 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        Boundaries of Congressional Districts (water areas included).
+        Boundaries of Congressional districts (water areas included).
 
         All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
       display_name: Congressional Districts (water areas included)
@@ -106,7 +106,7 @@ columns:
 - id: congdist
   name: CongDist
   data_type: integer
-  description: US House of Representatives Congressional District Number for the State
+  description: US House of Representatives congressional district number for the State
     of New York.
   example: None
 - id: the_geom

--- a/products/lion/congressional_districts/metadata.yml
+++ b/products/lion/congressional_districts/metadata.yml
@@ -45,7 +45,7 @@ destinations:
   - id: nycg_metadata.pdf
     custom:
       destination_use: attachment
-  - id: shapefile_wi
+  - id: shapefile
     custom:
       destination_use: dataset_file
   custom:

--- a/products/lion/congressional_districts/metadata.yml
+++ b/products/lion/congressional_districts/metadata.yml
@@ -6,7 +6,7 @@ attributes:
 
     All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Congressional Districts
-  each_row_is_a: Congressional District
+  each_row_is_a: Congressional district
   tags:
   - geographic
   - voting

--- a/products/lion/congressional_districts/metadata.yml
+++ b/products/lion/congressional_districts/metadata.yml
@@ -2,9 +2,9 @@ id: congressional_districts
 
 attributes:
   description: |-
-    GIS data: Boundaries of Congressional Districts.
+    Boundaries of Congressional Districts.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Congressional Districts
   each_row_is_a: Congressional District
   tags:
@@ -21,6 +21,7 @@ attributes:
   - election
   - congressional districts
   - dcp
+  date_made_public: []
 
 assembly: []
 
@@ -75,10 +76,10 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        GIS data: Boundaries of Congressional Districts (water areas included).
+        Boundaries of Congressional Districts (water areas included).
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
-      display_name: Congressional Districts (Water Areas Included)
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
+      display_name: Congressional Districts (water areas included)
     overridden_columns:
     - id: shape_length
       name: shape_leng
@@ -109,14 +110,17 @@ columns:
     of New York.
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description: []
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None

--- a/products/lion/election_districts/metadata.yml
+++ b/products/lion/election_districts/metadata.yml
@@ -2,7 +2,7 @@ id: election_districts
 
 attributes:
   description: |-
-    Boundaries of Election Districts.
+    Boundaries of election districts.
 
     All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Election Districts
@@ -74,7 +74,7 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        Boundaries of Election Districts (water areas included).
+        Boundaries of election districts (water areas included).
 
         All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
       display_name: Election Districts (water areas included)
@@ -104,7 +104,7 @@ columns:
 - id: electdist
   name: ElectDist
   data_type: integer
-  description: Three digit election district number proceeded by the two digit state
+  description: Three digit election district number preceded by the two digit state
     assembly district.
   example: None
 - id: the_geom

--- a/products/lion/election_districts/metadata.yml
+++ b/products/lion/election_districts/metadata.yml
@@ -2,13 +2,13 @@ id: election_districts
 
 attributes:
   description: |-
-    GIS data: Boundaries of Election Districts.
+    Boundaries of Election Districts.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Election Districts
-  each_row_is_a: Election District
+  each_row_is_a: Election district
   tags:
-  - 'political & election districts gis: election districts'
+  - political
   - dcp
   - geographic
   - voting
@@ -19,6 +19,7 @@ attributes:
   - boundary
   - elect
   - election
+  date_made_public: []
 
 assembly: []
 
@@ -73,10 +74,10 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        GIS data: Boundaries of Election Districts (Water Areas Included).
+        Boundaries of Election Districts (water areas included).
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
-      display_name: Election Districts (Water Areas Included)
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
+      display_name: Election Districts (water areas included)
     overridden_columns:
     - id: shape_length
       name: shape_leng
@@ -107,14 +108,17 @@ columns:
     assembly district.
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description: []
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None

--- a/products/lion/fire_battalions/metadata.yml
+++ b/products/lion/fire_battalions/metadata.yml
@@ -2,16 +2,17 @@ id: fire_battalions
 
 attributes:
   description: |-
-    GIS data: Boundaries of Fire Battalions.
+    Boundaries of fire battalions.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Fire Battalions
-  each_row_is_a: Fire Battalion
+  each_row_is_a: Fire battalion
   tags:
   - fire battalions
   - dcp
   - public safety
   - fdny
+  date_made_public: []
 
 assembly: []
 
@@ -59,17 +60,20 @@ columns:
 - id: firebn
   name: FireBN
   data_type: integer
-  description: The battalion number servicing the district
+  description: The battalion number servicing the district.
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description: []
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None

--- a/products/lion/fire_companies/metadata.yml
+++ b/products/lion/fire_companies/metadata.yml
@@ -2,16 +2,17 @@ id: fire_companies
 
 attributes:
   description: |-
-    GIS data: Boundaries of Fire Companies.
+    Boundaries of fire companies.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Fire Companies
-  each_row_is_a: Fire Company
+  each_row_is_a: Fire company
   tags:
   - fire companies
   - dcp
   - public safety
   - fdny
+  date_made_public: []
 
 assembly: []
 
@@ -80,27 +81,30 @@ columns:
 - id: fire_company_number
   name: FireCoNum
   data_type: integer
-  description: The company number servicing the district
+  description: The company number servicing the district.
   example: None
 - id: fire_division
   name: FireDiv
   data_type: text
-  description: The division number servicing the district
+  description: The division number servicing the district.
   example: None
 - id: fire_battalion
   name: FireBN
   data_type: integer
-  description: The battalion number servicing the district
+  description: The battalion number servicing the district.
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description: []
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None

--- a/products/lion/fire_divisions/metadata.yml
+++ b/products/lion/fire_divisions/metadata.yml
@@ -2,16 +2,17 @@ id: fire_divisions
 
 attributes:
   description: |-
-    GIS data: Boundaries of Fire Divisions.
+    Boundaries of fire divisions.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Fire Divisions
-  each_row_is_a: Fire Division
+  each_row_is_a: Fire division
   tags:
   - fire divisions
   - dcp
   - public safety
   - fdny
+  date_made_public: []
 
 assembly: []
 
@@ -59,17 +60,20 @@ columns:
 - id: firediv
   name: FireDiv
   data_type: integer
-  description: The fire division number servicing the district
+  description: The fire division number servicing the district.
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description: []
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None

--- a/products/lion/health_areas/metadata.yml
+++ b/products/lion/health_areas/metadata.yml
@@ -2,16 +2,17 @@ id: health_areas
 
 attributes:
   description: |-
-    GIS data: Boundaries of Health Areas.
+    Boundaries of health areas.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Health Areas
-  each_row_is_a: Health Area
+  each_row_is_a: Health area
   tags:
   - health areas
   - dcp
   - health
   - city planning
+  date_made_public: []
 
 assembly: []
 
@@ -81,7 +82,7 @@ columns:
 - id: boro_name
   name: BoroName
   data_type: text
-  description: Borough Name.
+  description: Borough name.
   example: Queens
   values:
   - value: Brooklyn
@@ -92,16 +93,20 @@ columns:
 - id: health_area
   name: HealthArea
   data_type: integer
-  example: None
-- id: shape_area
-  name: ShapeArea
-  data_type: decimal
-  example: None
-- id: shape_length
-  name: ShapeLength
-  data_type: decimal
+  description: []
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description: []
+  example: None
+- id: shape_length
+  name: Shape_Length
+  data_type: decimal
+  description: Length of feature in internal units.
+  example: None
+- id: shape_area
+  name: Shape_Area
+  data_type: decimal
+  description: Area of feature in internal units squared.
   example: None

--- a/products/lion/health_center_districts/metadata.yml
+++ b/products/lion/health_center_districts/metadata.yml
@@ -4,11 +4,12 @@ attributes:
   description: |-
     Health Center Districts - by Department of City Planning.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Health Center Districts
   each_row_is_a: Health Center District
   tags:
   - 'gis data: boundaries of health districts'
+  date_made_public: '2/23/2015'
 
 assembly: []
 
@@ -91,15 +92,18 @@ columns:
   data_type: integer
   description: Denotes the Health Center number
   example: None
-- id: shape_area
-  name: Shape_Area
-  data_type: decimal
-  example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
+  example: None
+- id: shape_area
+  name: Shape_Area
+  data_type: decimal
+  description: Area of feature in internal units squared.
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description: []
   example: None

--- a/products/lion/health_center_districts/metadata.yml
+++ b/products/lion/health_center_districts/metadata.yml
@@ -90,7 +90,7 @@ columns:
 - id: health_center_district
   name: HealthCenterDistrict
   data_type: integer
-  description: Denotes the Health Center number
+  description: Denotes the Health Center number.
   example: None
 - id: shape_length
   name: Shape_Length

--- a/products/lion/hurricane_evacuation_zones/metadata.yml
+++ b/products/lion/hurricane_evacuation_zones/metadata.yml
@@ -2,17 +2,18 @@ id: hurricane_evacuation_zones
 
 attributes:
   description: |-
-    "Hurricane Evacuation Zones are determined by New York City Emergency Management and represent varying threat levels of coastal flooding resulting from storm surge. Hurricane evacuation zones should not be confused with flood insurance risk zones, which are designated by FEMA and available in the form of Flood Insurance Rate Maps (FIRMs).
+    Hurricane Evacuation Zones are determined by New York City Emergency Management and represent varying threat levels of coastal flooding resulting from storm surge. Hurricane evacuation zones should not be confused with flood insurance risk zones, which are designated by FEMA and available in the form of Flood Insurance Rate Maps (FIRMs).
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Hurricane Evacuation Zones
-  each_row_is_a: Hurricane Evacuation Zone
+  each_row_is_a: Hurricane evacuation zone
   tags:
   - nycem
   - evacuation
   - hurricane
   - zones
-
+  date_made_public: '7/14/2015'
+  
 assembly: []
 
 custom: {}
@@ -60,17 +61,20 @@ columns:
 - id: hurricane_evacuation_zone
   name: HurricaneEvacuationZone
   data_type: text
-  description: Hurricane Evacuation Zone
+  description: Hurricane evacuation zone
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description: []
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None

--- a/products/lion/hurricane_evacuation_zones/metadata.yml
+++ b/products/lion/hurricane_evacuation_zones/metadata.yml
@@ -61,7 +61,7 @@ columns:
 - id: hurricane_evacuation_zone
   name: HurricaneEvacuationZone
   data_type: text
-  description: Hurricane evacuation zone
+  description: Hurricane evacuation zone.
   example: None
 - id: the_geom
   name: the_geom

--- a/products/lion/municipal_court_districts/metadata.yml
+++ b/products/lion/municipal_court_districts/metadata.yml
@@ -2,11 +2,11 @@ id: municipal_court_districts
 
 attributes:
   description: |-
-    GIS data: Boundaries of Municipal Court Districts.
+    Boundaries of Municipal Court districts.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Municipal Court Districts
-  each_row_is_a: Municipal Court District
+  each_row_is_a: Municipal Court district
   tags:
   - municipal court districts
   - dcp
@@ -14,6 +14,7 @@ attributes:
   - judicial
   - judge
   - law
+  date_made_public: '1/31/2013'
 
 assembly: []
 
@@ -68,9 +69,9 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        GIS data: Boundaries of Municipal Court Districts. (water areas included)
+        Boundaries of Municipal Court districts. (water areas included)
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
       display_name: Municipal Court Districts  (water areas included)
     overridden_columns:
     - id: shape_length
@@ -102,17 +103,12 @@ columns:
 - id: municourt
   name: MuniCourt
   data_type: integer
-  description: Municipal Court District Number
-  example: None
-- id: state_senate_district
-  name: State Senate District
-  data_type: integer
-  description: Municipal Court District Number
+  description: Municipal Court district number.
   example: None
 - id: borocode
   name: BoroCode
   data_type: text
-  description: Borough code for the borough in which the census block is located.
+  description: Borough code for the borough in which the Municipal Court district is located.
   example: '4'
   values:
   - value: '1'
@@ -137,14 +133,17 @@ columns:
   - value: Queens
   - value: Staten Island
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description: []
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None

--- a/products/lion/police_precincts/metadata.yml
+++ b/products/lion/police_precincts/metadata.yml
@@ -2,18 +2,13 @@ id: police_precincts
 
 attributes:
   description: |-
-    GIS data: Boundaries of Police Precincts.
+    Boundaries of police precincts.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: Police Precincts
-  each_row_is_a: Police Precinct
+  each_row_is_a: Police precinct
   tags:
-  - police precincts
   - dcp
-  - geographic
-  - location
-  - map
-  - cartography
   - safety
   - crime
   - boundary
@@ -22,12 +17,9 @@ attributes:
   - cop
   - division
   - precinct
-  - precincts
   - gis
   - jurisdiction
-  - school
-  - health
-  - 'fire & police gis: police precincts'
+  date_made_public: '1/31/2013'
 
 assembly: []
 
@@ -75,17 +67,20 @@ columns:
 - id: precinct
   name: Precinct
   data_type: integer
-  description: Denotes the precinct number serviced by the police precinct
+  description: Denotes the precinct number serviced by the police precinct.
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description: []
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None

--- a/products/lion/school_districts/metadata.yml
+++ b/products/lion/school_districts/metadata.yml
@@ -2,17 +2,18 @@ id: school_districts
 
 attributes:
   description: |-
-    GIS data: Boundaries of School Districts.
+    Boundaries of school districts.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: School Districts
-  each_row_is_a: School District
+  each_row_is_a: School district
   tags:
   - school districts
   - education
   - dcp
   - city planning
   - maps
+  date_made_public: '1/31/2013'
 
 assembly: []
 
@@ -62,17 +63,20 @@ columns:
 - id: school_district
   name: SchoolDistrict
   data_type: integer
-  description: The school district identifier the region defines
+  description: The school district identifier the region defines.
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description: []
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None

--- a/products/lion/state_assembly_districts/metadata.yml
+++ b/products/lion/state_assembly_districts/metadata.yml
@@ -2,18 +2,19 @@ id: state_assembly_districts
 
 attributes:
   description: |-
-    GIS data: Boundaries of State Assembly Districts.
+    Boundaries of State Assembly districts.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: State Assembly Districts
-  each_row_is_a: State Assembly District
+  each_row_is_a: State Assembly district
   tags:
-  - 'gis data: state assembly districts'
+  - state assembly districts
   - boundary
   - boundaries
   - dcp
   - city planning
   - politics
+  date_made_public: '4/4/2013'
 
 assembly: []
 
@@ -68,9 +69,9 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        GIS data: Boundaries of State Assembly Districts (water areas included).
+        Boundaries of State Assembly districts (water areas included).
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
       display_name: State Assembly Districts (water areas included)
     overridden_columns:
     - id: shape_length
@@ -84,9 +85,9 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        GIS data: Boundaries of State Assembly Districts.
+        Boundaries of State Assembly districts.
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
       display_name: State Assembly Districts
     overridden_columns:
     - id: shape_length
@@ -108,17 +109,20 @@ columns:
 - id: assembly_district
   name: AssemblyDistrict
   data_type: integer
-  description: State Assembly District Number
+  description: State Assembly district number.
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description:
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None

--- a/products/lion/state_senate_districts/metadata.yml
+++ b/products/lion/state_senate_districts/metadata.yml
@@ -2,11 +2,11 @@ id: state_senate_districts
 
 attributes:
   description: |-
-    GIS data: Boundaries of State Senate Districts.
+    Boundaries of State Senate districts.
 
-    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+    All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
   display_name: State Senate Districts
-  each_row_is_a: State Senate District
+  each_row_is_a: State Senate district
   tags:
   - state senate districts
   - dcp
@@ -19,6 +19,7 @@ attributes:
   - senate
   - district
   - boundary
+  date_made_public: '1/31/2013'
 
 assembly: []
 
@@ -73,10 +74,10 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        GIS data: Boundaries of State Senate Districts (water areas included).
+        Boundaries of State Senate Districts (water areas included).
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
-      display_name: State Senate Districts
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
+      display_name: State Senate Districts (water areas included)
     overridden_columns:
     - id: shape_length
       name: shape_leng
@@ -89,9 +90,9 @@ files:
   dataset_overrides:
     attributes:
       description: |-
-        GIS data: Boundaries of State Senate Districts.
+        Boundaries of State Senate Districts.
 
-        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE- Archive</a>.
+        All previously released versions of this data are available at <a href="https://www.nyc.gov/site/planning/data-maps/open-data/bytes-archive.page?sorts%5Byear%5D=0">BYTES of the BIG APPLE - Archive</a>.
     overridden_columns:
     - id: shape_length
       name: shape_leng
@@ -112,17 +113,20 @@ columns:
 - id: state_senate_district
   name: StateSenateDistrict
   data_type: integer
-  description: New York State Senate District Number
+  description: New York State Senate district number.
   example: None
 - id: the_geom
-  name: Shape
+  name: the_geom
   data_type: geometry
+  description:
   example: None
 - id: shape_length
   name: Shape_Length
   data_type: decimal
+  description: Length of feature in internal units.
   example: None
 - id: shape_area
   name: Shape_Area
   data_type: decimal
+  description: Area of feature in internal units squared.
   example: None


### PR DESCRIPTION
*work in progress*

- [ ] All datasets need values for:
  - "Data Provided By"
  - "Category"
  - "Update" section
    - "Update Frequency"
    - "Automation"
- [ ] Atomic Polygon dataset needs to be re-published to fix missing attachment
- [ ] [New URL field](https://nyco365.sharepoint.com/:x:/r/sites/NYCPLANNING/itd/edm/Shared%20Documents/PROJECTS/GIS/Open%20Data/[Open_Data.xlsx](https://nyco365.sharepoint.com/:x:/r/sites/NYCPLANNING/itd/edm/Shared%20Documents/PROJECTS/GIS/Open%20Data/Open_Data.xlsx?d=w6735537b8d8e437ab5e53a6b54194b24&csf=1&web=1&e=3cabib&nav=MTJfQzExX3tDRkQ2NzMyRi1CN0UyLTQwM0YtQkM2RS1GNERGNDAzNDZFNER9)?d=w6735537b8d8e437ab5e53a6b54194b24&csf=1&web=1&e=3cabib&nav=MTJfQzExX3tDRkQ2NzMyRi1CN0UyLTQwM0YtQkM2RS1GNERGNDAzNDZFNER9) in tracking sheet for City Council Dist erroneously points to a [water included page](https://data.cityofnewyork.us/dataset/City-Council-Districts-Water-Areas-Included-/872g-cjhh/about_data), duplicating the actual water included page but with a distinct four-four
- [ ] "Date Made Public" value can differ between the water included and water not included versions of a dataset, but the YAML currently only supports a single value for the pair. See Community Districts for example ([wi](https://data.cityofnewyork.us/dataset/Community-Districts-Water-Areas-Included-/mzpm-a6vd) and [non-wi](https://data.cityofnewyork.us/City-Government/Community-Districts/yfnk-k7r4))
- [ ] "Tags" values can differ between the water included and water not included versions of a dataset, but no explicit overrides are present
  - May need to be confirmed for all datasets with a wi/non-wi datasets