### PR TITLE
Add publish frequency to PLUTO (and fix ds ids)

### DIFF
--- a/products/pluto/change_file/metadata.yml
+++ b/products/pluto/change_file/metadata.yml
@@ -1,4 +1,4 @@
-id: pluto_change_file
+id: change_file
 
 attributes:
   description: |-

--- a/products/pluto/metadata.yml
+++ b/products/pluto/metadata.yml
@@ -1,5 +1,8 @@
 id: pluto
 
+dataset_defaults:
+  publishing_frequency: Quarterly
+
 datasets:
 - change_file
 - pluto

--- a/products/pluto/pluto/metadata.yml
+++ b/products/pluto/pluto/metadata.yml
@@ -1,4 +1,4 @@
-id: primary_land_use_tax_lot_output_pluto
+id: pluto
 
 attributes:
   description: |-


### PR DESCRIPTION
The Publishing Frequency change is pretty self-evident. The dataset ids is a little less so... I'm not sure whether we should require the folder name of the dataset to match the dataset.id. I'm not sure if anything breaks currently when they don't match up. But for now, keeping with the convention of having them be the same.