### PR TITLE
Ar feb opendata review

### DIFF
--- a/products/dcm/arterials_major_streets/metadata.yml
+++ b/products/dcm/arterials_major_streets/metadata.yml
@@ -43,9 +43,9 @@ destinations:
       - id: data_dictionary_pdf
         custom:
           destination_use: attachment
-      - id: oti_data_dictionary
-        custom:
-          destination_use: attachment
+      # - id: oti_data_dictionary
+      #   custom:
+      #     destination_use: attachment
     custom:
       four_four: 6r5z-bkpx
   - id: bytes

--- a/products/dcm/city_map_alterations/metadata.yml
+++ b/products/dcm/city_map_alterations/metadata.yml
@@ -42,9 +42,9 @@ destinations:
       - id: data_dictionary_pdf
         custom:
           destination_use: attachment
-      - id: oti_data_dictionary
-        custom:
-          destination_use: attachment
+      # - id: oti_data_dictionary
+      #   custom:
+      #     destination_use: attachment
     custom:
       four_four: 5iv5-v7sg
   - id: bytes

--- a/products/dcm/digital_city_map/metadata.yml
+++ b/products/dcm/digital_city_map/metadata.yml
@@ -55,9 +55,9 @@ destinations:
       - id: data_dictionary_pdf
         custom:
           destination_use: attachment
-      - id: oti_data_dictionary
-        custom:
-          destination_use: attachment
+      # - id: oti_data_dictionary
+      #   custom:
+      #     destination_use: attachment
     custom:
       four_four: qrhk-k5wn
   - id: bytes

--- a/products/dcm/street_center_line/metadata.yml
+++ b/products/dcm/street_center_line/metadata.yml
@@ -50,9 +50,9 @@ destinations:
       - id: data_dictionary_pdf
         custom:
           destination_use: attachment
-      - id: oti_data_dictionary
-        custom:
-          destination_use: attachment
+      # - id: oti_data_dictionary
+      #   custom:
+      #     destination_use: attachment
     custom:
       four_four: er35-3npf
   - id: bytes

--- a/products/dcm/street_name_changes/metadata.yml
+++ b/products/dcm/street_name_changes/metadata.yml
@@ -57,9 +57,9 @@ destinations:
       - id: areas_data_dictionary_pdf
         custom:
           destination_use: attachment
-      - id: oti_data_dictionary_areas
-        custom:
-          destination_use: attachment
+      # - id: oti_data_dictionary_areas
+      #   custom:
+      #     destination_use: attachment
     custom:
       four_four: nzui-5vt3
 
@@ -84,9 +84,9 @@ destinations:
       - id: lines_data_dictionary_pdf
         custom:
           destination_use: attachment
-      - id: oti_data_dictionary_lines
-        custom:
-          destination_use: attachment
+      # - id: oti_data_dictionary_lines
+      #   custom:
+      #     destination_use: attachment
     custom:
       four_four: i3nt-3kau
 
@@ -111,9 +111,9 @@ destinations:
       - id: points_data_dictionary_pdf
         custom:
           destination_use: attachment
-      - id: oti_data_dictionary_points
-        custom:
-          destination_use: attachment
+      # - id: oti_data_dictionary_points
+      #   custom:
+      #     destination_use: attachment
     custom:
       four_four: hsi9-e2ec
 

--- a/products/zoning/commercial_overlay_district/metadata.yml
+++ b/products/zoning/commercial_overlay_district/metadata.yml
@@ -31,9 +31,9 @@ destinations:
       - id: shapefile
         custom:
           destination_use: dataset_file
-      - id: oti_data_dictionary
-        custom:
-          destination_use: attachment
+      # - id: oti_data_dictionary
+      #   custom:
+      #     destination_use: attachment
     custom:
       four_four: aaxv-7bvq
   - id: bytes

--- a/products/zoning/limited_height_districts/metadata.yml
+++ b/products/zoning/limited_height_districts/metadata.yml
@@ -30,9 +30,9 @@ destinations:
   - id: shapefile
     custom:
       destination_use: dataset_file
-  - id: oti_data_dictionary
-    custom:
-      destination_use: attachment
+  # - id: oti_data_dictionary
+  #   custom:
+  #     destination_use: attachment
   custom:
     four_four: eh65-uhvn
 - id: bytes

--- a/products/zoning/special_purpose_districts/metadata.yml
+++ b/products/zoning/special_purpose_districts/metadata.yml
@@ -36,9 +36,9 @@ destinations:
   - id: shapefile
     custom:
       destination_use: dataset_file
-  - id: oti_data_dictionary
-    custom:
-      destination_use: attachment
+  # - id: oti_data_dictionary
+  #   custom:
+  #     destination_use: attachment
   custom:
     four_four: qs7n-2xb8
 - id: bytes

--- a/products/zoning/special_purpose_districts_subdistricts/metadata.yml
+++ b/products/zoning/special_purpose_districts_subdistricts/metadata.yml
@@ -35,9 +35,9 @@ destinations:
   - id: shapefile
     custom:
       destination_use: dataset_file
-  - id: oti_data_dictionary
-    custom:
-      destination_use: attachment
+  # - id: oti_data_dictionary
+  #   custom:
+  #     destination_use: attachment
   custom:
     four_four: 9ng7-qsbs
 - id: bytes

--- a/products/zoning/zoning_districts/metadata.yml
+++ b/products/zoning/zoning_districts/metadata.yml
@@ -36,9 +36,9 @@ destinations:
   - id: shapefile
     custom:
       destination_use: dataset_file
-  - id: oti_data_dictionary
-    custom:
-      destination_use: attachment
+  # - id: oti_data_dictionary
+  #   custom:
+  #     destination_use: attachment
   custom:
     four_four: frkw-si7h
 - id: bytes

--- a/products/zoning/zoning_map_amendments/metadata.yml
+++ b/products/zoning/zoning_map_amendments/metadata.yml
@@ -32,9 +32,9 @@ destinations:
   - id: shapefile
     custom:
       destination_use: dataset_file
-  - id: oti_data_dictionary
-    custom:
-      destination_use: attachment
+  # - id: oti_data_dictionary
+  #   custom:
+  #     destination_use: attachment
   custom:
     four_four: k5u6-psh6
 - id: bytes


### PR DESCRIPTION
Commenting out the OTI XLXS so that it doesn't hold up review for GIS. 

There is an issue we'll need to fix for Street Name Changes, which has multiple destinations... specifically the OTI XLSX is generated for the base dataset, but not the overrides. So it would be correct for "Digital City Map (DCM) - Street Name Changes (Areas)" but wrong for the overridden dataset, "Digital City Map (DCM) - Street Name Changes (Points)".