### PR TITLE
Make Zoning distributable from Bytes

### DIFF
--- a/products/zoning/commercial_overlay_district/metadata.yml
+++ b/products/zoning/commercial_overlay_district/metadata.yml
@@ -16,7 +16,15 @@ attributes:
   - NYC
   - Department of City Planning
   - DCP
-assembly: []
+
+assembly:
+- id: dcm_multilayer
+  filename: nycgiszoningfeatures_shp.zip
+  type: multilayer_shapefile
+  contents:
+  - id: shapefile
+    custom:
+      layer_name: nyco
 
 custom: {}
 
@@ -39,6 +47,9 @@ destinations:
   - id: bytes
     type: bytes
     files:
+      - id: dcm_multilayer
+        custom:
+          url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycgiszoningfeatures_{{ version }}shp.zip
       - id: metadata_pdf
         custom:
           url: https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/data-tools/bytes/nyco_metadata.pdf

--- a/products/zoning/limited_height_districts/metadata.yml
+++ b/products/zoning/limited_height_districts/metadata.yml
@@ -15,7 +15,15 @@ attributes:
   - NYC
   - Department of City Planning
   - DCP
-assembly: []
+
+assembly:
+- id: dcm_multilayer
+  filename: nycgiszoningfeatures_shp.zip
+  type: multilayer_shapefile
+  contents:
+  - id: shapefile
+    custom:
+      layer_name: nylh
 
 custom: {}
 
@@ -38,6 +46,9 @@ destinations:
 - id: bytes
   type: bytes
   files:
+  - id: dcm_multilayer
+    custom:
+      url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycgiszoningfeatures_{{ version }}shp.zip
   - id: metadata_pdf
     custom:
       url: https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/data-tools/bytes/nylh_metadata.pdf

--- a/products/zoning/special_purpose_districts/metadata.yml
+++ b/products/zoning/special_purpose_districts/metadata.yml
@@ -21,7 +21,15 @@ attributes:
   - NYC
   - Department of City Planning
   - DCP
-assembly: []
+
+assembly:
+- id: dcm_multilayer
+  filename: nycgiszoningfeatures_shp.zip
+  type: multilayer_shapefile
+  contents:
+  - id: shapefile
+    custom:
+      layer_name: nysp
 
 custom: {}
 
@@ -44,6 +52,9 @@ destinations:
 - id: bytes
   type: bytes
   files:
+  - id: dcm_multilayer
+    custom:
+      url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycgiszoningfeatures_{{ version }}shp.zip
   - id: metadata_pdf
     custom:
       url: https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/data-tools/bytes/nysp_metadata.pdf

--- a/products/zoning/special_purpose_districts_subdistricts/metadata.yml
+++ b/products/zoning/special_purpose_districts_subdistricts/metadata.yml
@@ -20,7 +20,15 @@ attributes:
   - NYC
   - Department of City Planning
   - DCP
-assembly: []
+
+assembly:
+- id: dcm_multilayer
+  filename: nycgiszoningfeatures_shp.zip
+  type: multilayer_shapefile
+  contents:
+  - id: shapefile
+    custom:
+      layer_name: nysp_sd
 
 custom: {}
 
@@ -43,6 +51,9 @@ destinations:
 - id: bytes
   type: bytes
   files:
+  - id: dcm_multilayer
+    custom:
+      url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycgiszoningfeatures_{{ version }}shp.zip
   - id: metadata_pdf
     custom:
       url: https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/data-tools/bytes/nysp_sd_metadata.pdf

--- a/products/zoning/zoning_districts/metadata.yml
+++ b/products/zoning/zoning_districts/metadata.yml
@@ -21,7 +21,14 @@ attributes:
   - Department of City Planning
   - DCP
 
-assembly: []
+assembly:
+- id: dcm_multilayer
+  filename: nycgiszoningfeatures_shp.zip
+  type: multilayer_shapefile
+  contents:
+  - id: shapefile
+    custom:
+      layer_name: nyzd
 
 custom: {}
 
@@ -44,6 +51,9 @@ destinations:
 - id: bytes
   type: bytes
   files:
+  - id: dcm_multilayer
+    custom:
+      url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycgiszoningfeatures_{{ version }}shp.zip
   - id: metadata_pdf
     custom:
       url: https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/data-tools/bytes/nyzd_metadata.pdf

--- a/products/zoning/zoning_features/metadata.yml
+++ b/products/zoning/zoning_features/metadata.yml
@@ -57,9 +57,6 @@ destinations:
 - id: bytes
   type: bytes
   files:
-  - id: shapefile
-    custom:
-      url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycgiszoningfeatures_{{ version }}shp.zip
   - id: fgdb
     custom:
       url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycgiszoningfeatures_{{ version }}fgdb.zip

--- a/products/zoning/zoning_map_amendments/metadata.yml
+++ b/products/zoning/zoning_map_amendments/metadata.yml
@@ -17,7 +17,15 @@ attributes:
   - NYC
   - Department of City Planning
   - DCP
-assembly: []
+
+assembly:
+- id: dcm_multilayer
+  filename: nycgiszoningfeatures_shp.zip
+  type: multilayer_shapefile
+  contents:
+  - id: shapefile
+    custom:
+      layer_name: nyzma
 
 custom: {}
 
@@ -40,6 +48,9 @@ destinations:
 - id: bytes
   type: bytes
   files:
+  - id: dcm_multilayer
+    custom:
+      url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycgiszoningfeatures_{{ version }}shp.zip
   - id: metadata_pdf
     custom:
       url: https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/data-tools/bytes/nyzma_metadata.pdf


### PR DESCRIPTION
Add an Assembly multi_layer_shape for Zoning datasets so that we can distribute them straight from bytes.

In each case, the existing script will disassemble them from bytes into a single shapefile, and push that.