### PR TITLE
Update a couple column override ID errors

### DIFF
--- a/products/pluto/pluto/metadata.yml
+++ b/products/pluto/pluto/metadata.yml
@@ -170,9 +170,9 @@ files:
       name: Ext
     - id: facilfar
       name: FacilFAR
-    - id: facilfar
-      name: AffResFAR
     - id: affresfar
+      name: AffResFAR
+    - id: mnffar
       name: ManuFAR
     - id: factryarea
       name: FactryArea


### PR DESCRIPTION
`overridden_columns` ids for affresfar and manufar appeared to be incorrect. Updated each.