### PR TITLE
Add test_dcpy product for dcpy test suite

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -45,6 +45,7 @@ products:
 - pops
 - projected_sea_level_rise
 - template_db
+- test_dcpy
 - transit_zones
 - waterfront_public_access_areas
 - waterfront_revitalization_program

--- a/products/test_dcpy/metadata.yml
+++ b/products/test_dcpy/metadata.yml
@@ -1,0 +1,13 @@
+id: test_dcpy
+
+attributes:
+  display_name: Test Product for DCPY
+  description: Product used for testing dcpy metadata functionality. Do not use in production.
+
+dataset_defaults:
+  publishing_frequency: "{{ test_product_freq }}"
+  publishing_purpose: legal compliance
+  current_version: product-default-2.0
+
+datasets:
+  - test_overrides

--- a/products/test_dcpy/test_overrides/metadata.yml
+++ b/products/test_dcpy/test_overrides/metadata.yml
@@ -1,0 +1,85 @@
+id: test_overrides
+
+attributes:
+  description: Dataset for testing override hierarchy and metadata merging behavior
+  display_name: Test Overrides Dataset
+  each_row_is_a: Test Record
+  publishing_frequency: "{{ test_dataset_freq }}"
+  current_version: dataset-override-3.0
+  tags:
+    - test
+    - dcpy
+
+assembly: []
+
+files:
+  - file:
+      id: shapefile
+      filename: test_overrides.shp.zip
+      type: shapefile
+    dataset_overrides:
+      attributes:
+        description: description overridden at file level
+        display_name: display_name overridden at file level
+        custom:
+          file_level_custom: file_value
+      overridden_columns:
+        - id: geom
+          description: Overridden geometry description at file level
+          custom:
+            file_level_col_custom: file_col_value
+        - id: test_field
+          data_type: text
+          values:
+            - value: A
+              description: Value A
+            - value: B
+              description: Value B
+  - file:
+      id: csv
+      filename: test_overrides.csv
+      type: csv
+    dataset_overrides:
+      omitted_columns:
+        - geom
+
+destinations:
+  - id: socrata
+    type: open_data
+    files:
+      - id: shapefile
+        custom:
+          destination_use: dataset_file
+    tags: [test_tag]
+    current_version: destination-override-4.0
+  - id: bytes
+    type: bytes
+    files:
+      - id: shapefile
+        dataset_overrides:
+          attributes:
+            description: description overridden at destination level
+            custom:
+              destination_level_custom: dest_value
+          overridden_columns:
+            - id: test_field
+              description: Destination-level column override
+          omitted_columns:
+            - another_field
+
+columns:
+  - id: geom
+    name: geom
+    data_type: geometry
+    description: Feature geometry
+    example: POINT(0 0)
+  - id: test_field
+    name: test_field
+    data_type: integer
+    description: Test field for override testing
+    example: "42"
+  - id: another_field
+    name: another_field
+    data_type: text
+    description: Another field for omitted columns testing
+    example: test

--- a/snippets/strings.yml
+++ b/snippets/strings.yml
@@ -86,3 +86,9 @@ current_version_waterfront_revitalization_program: 2016.1
 current_version_zap: 20260427
 current_version_zoning: 202604
 current_version_zoning_map_index:
+
+# Test variables for dcpy test suite
+test_product_freq: Test Product Frequency
+test_dataset_freq: Test Dataset Frequency
+test_agency: DCP
+test_version: 24c


### PR DESCRIPTION
- Create products/test_dcpy/ with test_overrides dataset
- Add comprehensive override hierarchy for testing:
  - Product-level: current_version product-default-2.0
  - Dataset-level: current_version dataset-override-3.0
  - Destination-level: current_version destination-override-4.0
- Include file and column override scenarios
- Add test template variables to snippets/strings.yml
- Add test_dcpy to products list in root metadata.yml

This product is used exclusively for testing dcpy metadata functionality and should not be used in production workflows.